### PR TITLE
Improve output messaging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/pwaller/docker-show-context
 
 require (
-	github.com/docker/docker v0.0.0-20180713101209-23f4a3d5091b
-
 	github.com/containerd/continuity v0.0.0-20180712174259-0377f7d76720 // indirect
+	github.com/docker/docker v0.0.0-20180713101209-23f4a3d5091b
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect


### PR DESCRIPTION
- Remove confusing message about totals excluding dockerignore.
- Explicitly state amount of content ignored by dockerignore.
- Write progress updates to stderr, so that stdout is useful and can be
  piped to a file.
- Don't write useful information to stderr.
- Minor improvements to output formatting.

Fixes #3.

New output example:
-------------------

```
Scanning local directory (in tar / on disk):
  24 / 1057 (62 / 216 MiB) (0.0s elapsed) .. completed

Excluded by .dockerignore: 1033 files totalling 153.98 MiB

Final .tar:
  24 files totalling 61.83 MiB (+ 0.02 MiB tar overhead)
  Took 0.04 seconds to build

Top 10 directories by time spent:
   40 ms: .
    1 ms: example

Top 10 directories by storage:
  61.83 MiB: .
   0.00 MiB: example

Top 10 directories by file count:
   23: .
    1: example

Top 10 file extensions by storage:
  57.10 MiB: 
   4.71 MiB: .exe
   0.01 MiB: .pprof
   0.01 MiB: .md
   0.01 MiB: .go
   0.00 MiB: .sum
   0.00 MiB: .mod
   0.00 MiB: .sh
   0.00 MiB: .gitignore
   0.00 MiB: .dockerignore
```

Old output example:
-------------------

```
2018/07/13 13:19:18 Building context...

(note: totals do not take into account dockerignore)
Creating tar: 11 / 1056 (35 / 216 MiB) (0.0s elapsed) .. completed

Top 10 directories by time spent:
   38 ms: .
    1 ms: example

Top 10 directories by storage:
  61.83 MiB: .
   0.00 MiB: example

Top 10 directories by file count:
   23: .
    1: example

Top 10 file extensions by storage:
  57.10 MiB: 
   4.71 MiB: .exe
   0.01 MiB: .pprof
   0.01 MiB: .md
   0.01 MiB: .go
   0.00 MiB: .sum
   0.00 MiB: .mod
   0.00 MiB: .sh
   0.00 MiB: .gitignore
   0.00 MiB: .dockerignore

2018/07/13 13:19:18 Total files: 24 total content: 61.83 MiB (+ 0.02 MiB tar overhead)
2018/07/13 13:19:18 Took 0.04 seconds to build tar
```