### PR TITLE
Readme: add `--rm` to docker run command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ context.
 
 ```sh
 docker build -t docker-show-context https://github.com/pwaller/docker-show-context.git
-docker run -v $PWD:/data docker-show-context
+docker run --rm -v $PWD:/data docker-show-context
 ```
 
 ## Getting started (binaries):


### PR DESCRIPTION
The `--rm` argument cleans up the container after the run.
There is no need to keep the container afterwards and this saves the user from cleaning it up manually.