### PR TITLE
Docker: Use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.11
-
+FROM golang:1.11 AS builder
 WORKDIR /app
-
 COPY . .
+ENV GO111MODULE=on
+RUN go build -o docker-show-context .
 
-RUN GO111MODULE=on go install -v
-
+FROM alpine:latest
+COPY --from=builder /app/docker-show-context /usr/local/bin
+RUN apk add --no-cache libc6-compat
 WORKDIR /data
-
-ENTRYPOINT "docker-show-context"
+ENTRYPOINT ["docker-show-context"]


### PR DESCRIPTION
- First stage: Compile the go binary from source
- Second stage:
  - alpine linux as base image
  - only copy the compiled go binary over from the first stage
  - install `libc6-compat` for compatibility between musl and glibc

- Final local image size is only 9.1 MB (for comparison: previously it was 1.04 GB)
- Compressed image size on Docker Hub is only 4.37 MB (for comparison: previously it was 495.98 MB)
 
Also: Fix entrypoint syntax to use exec form to call the binary directly (previously it used shell form, which always calls /bin/sh)

btw @pwaller: Do you intend to publish the image on e.g. Docker Hub? Then the users could save the step of building the image locally.
For testing I used https://hub.docker.com/repository/docker/shaderecker/docker-show-context but maybe you want to publish it under your own user (setting up automated builds from the GitHub repo is pretty easy).